### PR TITLE
showdeps added

### DIFF
--- a/showdeps
+++ b/showdeps
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+export LC_ALL=C.UTF-8
+
+OOPS() { { printf 'OOPS:'; printf ' %q' "$@"; printf '\n'; } >&2; exit 23; }
+
+showdep()
+{
+export PKG="$1"
+gawk '
+NR==1,/^Dependencies:/	{ next }
+/^Provides:/,0		{ next }
+
+BEGIN	{
+	OP[0]	= "";
+	OP[1]	= "<=";
+	OP[2]	= ">=";
+	OP[3]	= "<<";
+	OP[4]	= ">>";
+	OP[5]	= "==";
+	OP[6]	= "!=";
+	for (a in OP) OP[a+16]=OP[a];
+	}
+
+{
+  delete pkg;
+  delete cmp;
+  j = 0;
+  for (i=3; i<=NF; i+=3)
+    {
+      pkg[j] = $i;
+      x = $(i+1); sub(/^[(]/,"",x);
+      y = $(i+2); sub(/[)]$/,"",y);
+      x = (x in OP) ? OP[x] : "### OOPS, unknown >>>" x "<<<";
+      if (x=="")
+        if (y=="(null)")
+          y = "";
+        else
+          x = "???OOPS???";
+      cmp[j] = x y;
+      j++;
+    }
+  ver=$1;
+  gsub(/'\''/,"",ver);
+  exec="apt-cache depends \"$PKG\"='\''"ver"'\''";
+  j = 0;
+  while (exec | getline)
+    {
+      printf "%s\t%s\t%s%s\n", ENVIRON["PKG"], ver, $0, ($1~/:$/) ? "\t(" cmp[j++] ")" : "";
+    }
+  close(exec)
+  print ""
+}
+' <(apt-cache showpkg "$1")
+}
+
+for p
+do
+	showdep "$p"
+done
+


### PR DESCRIPTION
This is a script which combines `apt-cache depends` with `apt-cache showpkg` to see the real dependencies including all details.

Very early code